### PR TITLE
Fix scikit-learn package name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setuptools.setup(
     ),
     include_package_data=True,
     install_requires=[
-          'matplotlib', 'numpy', 'pyzmq', 'plotly', 'torchstat', 'ipywidgets', 'sklearn', 'nbformat', 'scikit-image' # , 'receptivefield'
+          'matplotlib', 'numpy', 'pyzmq', 'plotly', 'torchstat', 'ipywidgets', 'scikit-learn', 'nbformat', 'scikit-image' # , 'receptivefield'
     ]
 )


### PR DESCRIPTION
The name of the PyPI package is scikit-learn. sklearn on PyPI is an alias which was added for convenience (see https://pypi.org/project/sklearn/ that recommends to use scikit-learn and not sklearn). If you use sklearn on PyPI, we may consider raising an error message at some point in the future.

See https://github.com/scikit-learn/scikit-learn/issues/8215 for more details.