### PR TITLE
Fix graph generation for PyTorch >= 1.2.0

### DIFF
--- a/tensorwatch/model_graph/hiddenlayer/pytorch_builder.py
+++ b/tensorwatch/model_graph/hiddenlayer/pytorch_builder.py
@@ -44,7 +44,7 @@ def pytorch_id(node):
     """Returns a unique ID for a node."""
     # After ONNX simplification, the scopeName is not unique anymore
     # so append node outputs to guarantee uniqueness
-    return node.scopeName() + "/outputs/" + "/".join([o.uniqueName() for o in node.outputs()])
+    return node.scopeName() + "/outputs/" + "/".join([str(o.unique()) for o in node.outputs()])
 
 
 def get_shape(torch_node):


### PR DESCRIPTION
The PyTorch graph import code in hiddenlayer.py is not compatible with
  PyTorch >= 1.2.0

PyTorch made a breaking change, renaming uniqueName() to debugName() in this commit:

https://github.com/pytorch/pytorch/commit/f7b2778cb1db148f1c901ea08abcbfa0e0a78f44

See the [issue in hiddenlayer](https://github.com/waleedka/hiddenlayer/issues/51). ([PR with fix](https://github.com/waleedka/hiddenlayer/pull/52))

Fixes #41 