### PR TITLE
Fix draw_model in Jupyter notebooks

### DIFF
--- a/tensorwatch/model_graph/hiddenlayer/pytorch_draw_model.py
+++ b/tensorwatch/model_graph/hiddenlayer/pytorch_draw_model.py
@@ -10,7 +10,7 @@ class DotWrapper:
         self.dot = dot
     def _repr_svg_(self):
         """Allows Jupyter notebook to render the graph automatically."""
-        return self.dot._repr_svg_()     
+        return self.dot.create_svg().decode()
     def save(self, filename, format="png"):
         # self.dot.format = format
         # directory, file_name = os.path.split(path)


### PR DESCRIPTION
Error calling method 'draw_model' used to visualize the model graph in Jupyter notebooks.
The fix is to use method 'pydot.Dot.create_svg()'
Fixes #50 