### PR TITLE
Go back to plain pydot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
           'matplotlib', 'numpy', 'pyzmq', 'plotly', 'ipywidgets',
-          'pydotz',
+          'pydot>=1.4.2',
           'nbformat', 'scikit-image', 'nbformat', 'pyyaml', 'scikit-image', 'graphviz' # , 'receptivefield'
     ]
 )


### PR DESCRIPTION
pydotz was a fork of pydotz but upstream has since released a version with the necessary patches.