### PR TITLE
fix: correct occured->occurred typo in pytorch_builder.py error message

### DIFF
--- a/tensorwatch/model_graph/hiddenlayer/pytorch_builder.py
+++ b/tensorwatch/model_graph/hiddenlayer/pytorch_builder.py
@@ -114,7 +114,7 @@ def import_graph(hl_graph, model, args, input_names=None, verbose=False):
             torch_graph = trace.graph
         except RuntimeError as e:
             print(e)
-            print('Error occured when creating jit trace for model.')
+            print('Error occurred when creating jit trace for model.')
             raise e
 
     # Dump list of nodes (DEBUG only)


### PR DESCRIPTION
## Summary
Corrected a typo in an error message in `tensorwatch/model_graph/hiddenlayer/pytorch_builder.py`:

- **Before:** `print('Error occured when creating jit trace for model.')`
- **After:** `print('Error occurred when creating jit trace for model.')`

This typo appears in the exception handler when JIT tracing fails during model graph creation - users would see this message directly.

## Verification
- Single file changed, 1 character fix
- No functionality change
- Matches other error message style in the codebase

---
*Submitted via GitHub API by Jah-yee*